### PR TITLE
Fixes tempfile on windows

### DIFF
--- a/helpers/pause.js
+++ b/helpers/pause.js
@@ -1,7 +1,7 @@
 const readlineSync = require('readline-sync');
 
 let pause = () => {
-    readlineSync.question('Press any key to continue ...');
+    readlineSync.keyInPause();
 };
 
 module.exports = pause;

--- a/helpers/progress.js
+++ b/helpers/progress.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const chalk = require('chalk');
 const argv = require('yargs').argv;
 
 let filename = '/tmp/index-' + process.cwd().split('/').pop() + '.tmp';

--- a/helpers/progress.js
+++ b/helpers/progress.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const chalk = require('chalk');
 const argv = require('yargs').argv;
 
-let filename = '/tmp/index-' + process.cwd().split('/').pop() + '.tmp';
+let cwd = process.cwd();
+let filename = '/tmp/index-' + cwd.split(cwd.match(/[/\\]/)).pop() + '.tmp';
 
 let get = () => {
     try {
@@ -19,7 +20,7 @@ let save = (index) => {
         let response = fs.writeFileSync(filename, index);
     } catch (err) {
         console.log(chalk.yellow(`
-            Could not create temp file.
+            Could not create file ${filename}.
             Your progress will not be saved
         `));
     }
@@ -27,4 +28,4 @@ let save = (index) => {
 
 if (argv.restart) save(0);
 
-module.exports = {get, save};
+module.exports = {get,save};

--- a/helpers/render.js
+++ b/helpers/render.js
@@ -1,10 +1,10 @@
 const cardinal = require('cardinal');
 const chalk = require('chalk');
-const inquirer = require('inquirer');
 const pause = require('./pause.js');
 const clear = require('clear');
 
 let render = (lesson) => {
+    clear();
     console.log(chalk.green(lesson.title));
     for (let step of lesson.gyan) {
         if (step.type === 'text') console.log(step.value);


### PR DESCRIPTION
Resolves undeclared dependency in progress.js:

```
C:\Users\a\AppData\Roaming\npm\node_modules\learn-es6\helpers\progress.js:20
        console.log(chalk.yellow(`
                    ^

ReferenceError: chalk is not defined
    at err (C:\Users\a\AppData\Roaming\npm\node_modules\learn-es6\helpers\progress.js:20:21)
    at Object.<anonymous> (C:\Users\a\AppData\Roaming\npm\node_modules\learn-es6\helpers\progress.js:27:19)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (C:\Users\a\AppData\Roaming\npm\node_modules\learn-es6\helpers\index.js:5:18)
```
